### PR TITLE
docs: update git clone url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Zero + Solid + TypeScript + Vite
 
 ```bash
-git clone git@github.com:rocicorp/hello-zero-solid.git
+git clone https://github.com/rocicorp/hello-zero-solid.git
 cd hello-zero-solid
 npm install
 npm run dev:db-up


### PR DESCRIPTION
The `git clone` command in the `README.md` file currently uses the SSH URL (`git@github.com:rocicorp/hello-zero-solid.git`). This can cause issues for users who have not set up SSH keys with GitHub, leading to a "permission denied" error.

This pull request updates the URL to use HTTPS (`https://github.com/rocicorp/hello-zero-solid.git`), which works for all users without any special configuration. This change makes it easier for new contributors to get started with the project.
